### PR TITLE
Fix: Feijouda page overflow issue: #69

### DIFF
--- a/site/brazil/feijoada.html
+++ b/site/brazil/feijoada.html
@@ -19,7 +19,7 @@
     }
 
     html,body{
-      height:100%;
+      /*height:100%;*/
       margin:0;
       font-family: 'Inter', system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
       background:


### PR DESCRIPTION
### Summary 
The pull request fixes the `Feijoada.html` page overflow. The upper part of the content was going out of bounds due to the `height=100%` on the `body` element.

### Changes Made
- Just delete or simply comment the `height=100%` part from the `style` part: `html,body{ /*height:100%;*/ ...` }.
- No other changes are needed in order to work.

### Testing
- Tested on different viewport sizes locally.

Closes #69
